### PR TITLE
In pymongo3, no need to use hosts_or_uri.

### DIFF
--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 18)
+VERSION = (0, 6, 19)
 
 
 def get_version():

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -106,8 +106,6 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
                 conn_settings['slaves'] = slaves
                 conn_settings.pop('read_preference')
 
-        if 'replicaSet' in conn_settings:
-            conn_settings['hosts_or_uri'] = conn_settings.pop('host', None)
         try:
             _connections[alias] = MongoClient(**conn_settings)
         except Exception, e:


### PR DESCRIPTION
See https://github.com/MongoEngine/mongoengine/blob/master/mongoengine/connection.py#L176 - but broadly speaking when on pymongo3 it all stays as host and doesn't get split out. As conversocial's mongoengine specifies pymongo==3.1 we don't need a conditional.