### PR TITLE
feat: noticket - Update Document __eq__/__ne__ to return NotImplemented

### DIFF
--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 20)
+VERSION = (0, 6, 21)
 
 
 def get_version():

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -1143,12 +1143,14 @@ class BaseDocument(object):
 
     def __eq__(self, other):
         if isinstance(other, self.__class__) and hasattr(other, 'id'):
-            if self.id == other.id:
-                return True
-        return False
+            return self.id == other.id
+        return NotImplemented
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        res = self.__eq__(other)
+        if res == NotImplemented:
+            return NotImplemented
+        return not res
 
     def __hash__(self):
         if self.pk is None:

--- a/tests/document.py
+++ b/tests/document.py
@@ -2279,5 +2279,45 @@ class DocumentTest(unittest.TestCase):
                                         }
                                     ) ]), "1,2")
 
+
+    def test_document_equality(self):
+        class A(Document):
+            name = StringField()
+
+        class B(Document):
+            name = StringField()
+
+        class SomethingElse(object):
+            def __init__(self, id, name):
+                self.id = id
+                self.name = name
+
+        a = A(id=1, name="BOOK")
+        a_ = A(id=1, name="BOOK")
+        b = B(id=1, name="BOOK")
+        somethingElse = SomethingElse(id=1, name="BOOK")
+
+        # ensure __eq__ returns NotImplemented
+        self.assertEqual(a.__eq__(a_), True)
+        self.assertEqual(a.__eq__(b), NotImplemented)
+        self.assertEqual(a.__eq__(somethingElse), NotImplemented)
+
+        # test equality
+        self.assertTrue(a == a_)
+        self.assertFalse(a == b)
+        self.assertFalse(a == somethingElse)
+
+        # test __ne__ returns NotImplemented
+        self.assertEqual(a.__ne__(a_), False)
+        self.assertEqual(a.__ne__(b), NotImplemented)
+        self.assertEqual(a.__ne__(somethingElse), NotImplemented)
+
+        # test not equal
+        self.assertFalse(a != a_)
+        self.assertTrue(a != b)
+        self.assertTrue(a != somethingElse)
+
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
when comparing to different classes.

Why? Short reason: We have the concept of MongoRef (a light wrapper that
holds a pointer to a MongoEngine document). When performing basic
equality checks we would like a MongoRef and Document of the same
type/id to be considered equal.

This update causes MongoEngine to return NotImplemented instead of False
when comparing against things that are not the same class. Which will
allow us to implement/allow the comparison in our MongoRef class.

https://docs.python.org/2/reference/datamodel.html

NotImplemented

This type has a single value. There is a single object with this value.
This object is accessed through the built-in name NotImplemented.
Numeric methods and rich comparison methods may return this value if
they do not implement the operation for the operands provided. (The
interpreter will then try the reflected operation, or some other
fallback, depending on the operator.) Its truth value is true.