### PR TITLE
Backport shard key fixes

### DIFF
--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 22)
+VERSION = (0, 6, 23)
 
 
 def get_version():

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -837,7 +837,7 @@ class BaseDocument(object):
                 self._mark_as_changed(name)
             return
 
-        if not self._created and name in self._meta.get('shard_key', tuple()):
+        if not self._created and name in self._meta.get('shard_key', tuple()) and self._data[name] != value:
             from queryset import OperationError
             raise OperationError(
                 "Shard Keys are immutable. Tried to update %s" % name)

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -687,7 +687,7 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
                     collection = base._get_collection_name()
                 # Propagate index options.
                 for key in ('index_background', 'index_drop_dups',
-                            'index_opts'):
+                            'index_opts', 'shard_key'):
                     if key in base._meta:
                         base_meta[key] = base._meta[key]
 

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -313,10 +313,7 @@ class Document(BaseDocument):
         .. versionadded:: 0.1.2
         .. versionchanged:: 0.6  Now chainable
         """
-        id_field = self._meta['id_field']
-        obj = self.__class__.objects(
-            **{id_field: self[id_field]}
-        ).first()
+        obj = self.__class__.objects(**self._object_key).first()
         for field in self._fields:
             setattr(self, field, self._reload(field, obj[field]))
         if self._dynamic:

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -267,7 +267,10 @@ class Document(BaseDocument):
         select_dict = {'pk': self.pk}
         shard_key = self.__class__._meta.get('shard_key', tuple())
         for k in shard_key:
-            select_dict[k] = getattr(self, k)
+            if k == '_id':
+                select_dict['id'] = getattr(self, 'id')
+            else:
+                select_dict[k] = getattr(self, k)
         return select_dict
 
     def update(self, **kwargs):

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -260,6 +260,16 @@ class Document(BaseDocument):
                 ref.save(**kwargs)
                 ref._changed_fields = []
 
+    @property
+    def _object_key(self):
+        """Dict to identify object in collection
+        """
+        select_dict = {'pk': self.pk}
+        shard_key = self.__class__._meta.get('shard_key', tuple())
+        for k in shard_key:
+            select_dict[k] = getattr(self, k)
+        return select_dict
+
     def update(self, **kwargs):
         """Performs an update on the :class:`~mongoengine.Document`
         A convenience wrapper to :meth:`~mongoengine.QuerySet.update`.
@@ -271,11 +281,7 @@ class Document(BaseDocument):
             raise OperationError('attempt to update a document not yet saved')
 
         # Need to add shard key to query, or you get an error
-        select_dict = {'pk': self.pk}
-        shard_key = self.__class__._meta.get('shard_key', tuple())
-        for k in shard_key:
-            select_dict[k] = getattr(self, k)
-        return self.__class__.objects(**select_dict).update_one(**kwargs)
+        return self.__class__.objects(**self._object_key).update_one(**kwargs)
 
     def delete(self, w=1):
         """Delete the :class:`~mongoengine.Document` from the database. This
@@ -284,7 +290,7 @@ class Document(BaseDocument):
         signals.pre_delete.send(self.__class__, document=self)
 
         try:
-            self.__class__.objects(pk=self.pk).delete(w=w)
+            self.__class__.objects(**self._object_key).delete(w=w)
         except pymongo.errors.OperationFailure, err:
             message = u'Could not delete document (%s)' % err.message
             raise OperationError(message)

--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,4 @@ setup(name='mongoengine',
       classifiers=CLASSIFIERS,
       install_requires=['pymongo==3.1', 'blinker==1.4'],
       test_suite='tests',
-      tests_require=['django>=1.3', 'pillow'])
+      tests_require=['django>=1.3,<=1.4.14', 'pillow'])

--- a/tests/document.py
+++ b/tests/document.py
@@ -2492,12 +2492,17 @@ class ShardedDocumentTest(unittest.TestCase):
             age = IntField()
 
             meta = {'allow_inheritance': True,
-                    'shard_key': ('region',)}
+                    'shard_key': ('region', '_id',)}
+        self.allow_tablescans(ShardedPerson)
         self.ensure_sharded(ShardedPerson)
         self.ShardedPerson = ShardedPerson
 
     def tearDown(self):
         self.ShardedPerson.drop_collection()
+
+    def allow_tablescans(self, model):
+        model.objects._collection.ensure_index([('_cls', pymongo.ASCENDING)],
+                                               background=True)
 
     def ensure_sharded(self, model):
         """

--- a/tests/document.py
+++ b/tests/document.py
@@ -2593,13 +2593,18 @@ class ShardedDocumentTest(unittest.TestCase):
 
     def test_fails_to_create_sharded_doc_without_shard_key(self):
         person = self.ShardedPerson(name='jandres')
-        with self.assertRaises(OperationError):
+        with self.assertRaises(OperationError) as cm:
             person.save()
+        self.assertIn('does not contain shard key', str(cm.exception))
 
     def test_reload_sharded(self):
         """Duplicate of test above with an actually sharded collection"""
         author = self.ShardedPerson(region='eu', name='dcrosta')
         author.save()
+        author.reload()
+        # Sanity check that reload doesn't leave debris thereby blocking a
+        # subsequent reload. We have no proof this would be the case, it's
+        # just the usual paranoia.
         author.reload()
 
     def test_abstract_document_with_shard_key(self):
@@ -2622,8 +2627,6 @@ class ShardedDocumentTest(unittest.TestCase):
 
         p1 = self.ShardedPerson.objects.first()
         self.assertEquals(p1.name, author.name)
-
-        self.ShardedPerson.drop_collection()
 
     def test_sharded_document_delete(self):
         """Ensure that document may be deleted using the delete method."""

--- a/tests/document.py
+++ b/tests/document.py
@@ -2479,6 +2479,21 @@ class DocumentTest(unittest.TestCase):
         self.assertTrue(a != b)
         self.assertTrue(a != somethingElse)
 
+    def test_abstract_document_with_shard_key(self):
+        class AbstractShardedDocument(Document):
+            meta = {'abstract': True,
+                    'shard_key': ('shard',)}
+            shard = StringField(required=True)
+
+        class Animal(AbstractShardedDocument):
+            name = StringField(required=True)
+
+        a = Animal(shard='eu', name='Kenneth')
+        a.save()
+
+        b = Animal(name='No shard specified!')
+        with self.assertRaises(ValidationError):
+            b.save()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/document.py
+++ b/tests/document.py
@@ -701,6 +701,17 @@ class DocumentTest(unittest.TestCase):
         self.assertEqual(person.name, "Mr Test User")
         self.assertEqual(person.age, 21)
 
+    def test_reload_sharded(self):
+        class Animal(Document):
+            superphylum = StringField()
+            meta = {'shard_key': ('superphylum',)}
+
+        Animal.drop_collection()
+        doc = Animal(superphylum = 'Deuterostomia')
+        doc.save()
+        doc.reload()
+        Animal.drop_collection()
+
     def test_reload_referencing(self):
         """Ensures reloading updates weakrefs correctly
         """


### PR DESCRIPTION
Running these tests in our stack requires:

```diff
diff --git a/tests/document.py b/tests/document.py
index 4b04f08..613913f 100644
--- a/tests/document.py
+++ b/tests/document.py
@@ -24,7 +24,7 @@ from mongoengine.connection import get_db, register_db
 class DocumentTest(unittest.TestCase):

     def setUp(self):
-        connect()
+        connect('default', port=27217)
         register_db('mongoenginetest')
         self.db = get_db()

```