### PR TITLE
DAF-6 — Pre/post connect signals

### DIFF
--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 23)
+VERSION = (0, 6, 24)
 
 
 def get_version():

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -2,7 +2,7 @@ import pymongo
 from pymongo import MongoClient, uri_parser
 from pymongo.read_preferences import ReadPreference
 
-from signals import pre_connect, post_connect
+import signals
 
 
 __all__ = ['ConnectionError', 'connect', 'register_connection',
@@ -108,9 +108,9 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
                 conn_settings.pop('read_preference')
 
         try:
-            pre_connect.send(alias, settings=conn_settings)
+            signals.pre_connect.send(alias, settings=conn_settings)
             _connections[alias] = MongoClient(**conn_settings)
-            post_connect.send(alias, settings=conn_settings, connection=_connections[alias])
+            signals.post_connect.send(alias, settings=conn_settings, connection=_connections[alias])
         except Exception, e:
             raise ConnectionError(
                 "Cannot connect to database %s :\n%s" % (alias, e))

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -2,6 +2,8 @@ import pymongo
 from pymongo import MongoClient, uri_parser
 from pymongo.read_preferences import ReadPreference
 
+from signals import pre_connect, post_connect
+
 
 __all__ = ['ConnectionError', 'connect', 'register_connection',
            'DEFAULT_CONNECTION_NAME']
@@ -106,7 +108,9 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
                 conn_settings.pop('read_preference')
 
         try:
+            pre_connect.send(alias, settings=conn_settings)
             _connections[alias] = MongoClient(**conn_settings)
+            post_connect.send(alias, settings=conn_settings, connection=_connections[alias])
         except Exception, e:
             raise ConnectionError(
                 "Cannot connect to database %s :\n%s" % (alias, e))

--- a/mongoengine/signals.py
+++ b/mongoengine/signals.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from blinker import Namespace
 
-__all__ = ['pre_init', 'post_init', 'pre_save', 'post_save',
-           'pre_delete', 'post_delete']
+__all__ = ['pre_connect', 'post_connect', 'pre_init', 'post_init',
+           'pre_save', 'post_save', 'pre_delete', 'post_delete']
 
 signals_available = True
 
@@ -10,6 +10,8 @@ signals_available = True
 # not put signals in here.  Create your own namespace instead.
 _signals = Namespace()
 
+pre_connect = _signals.signal('pre_connect')
+post_connect = _signals.signal('post_connect')
 pre_init = _signals.signal('pre_init')
 post_init = _signals.signal('post_init')
 pre_save = _signals.signal('pre_save')


### PR DESCRIPTION
Implement new `pre_connect`/`post_connect` signals that will be emitted whenever a new `MongoClient` instance is created (i.e. *not* when one is reused from the connection cache).

This is needed in the monolith in order to delay Shardmonster initialisation until a Mongo connection is attempted.