### PR TITLE
fix: noticket - allows_pre_delete_signals_on_reverse_delete_rule_cascade

### DIFF
--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 24)
+VERSION = (0, 6, 25)
 
 
 def get_version():


### PR DESCRIPTION
This change is a reworking of an existing fix from MongoEngine actual, link here:
https://github.com/MongoEngine/mongoengine/pull/105

Their fix isn't great, as it breaks the "Principle of least astonishment", causing queryset.delete to accept two different types of querysets, which differing behaviour to each. However, I would rather at least try to follow the main mongoengine so that one day we can bring ours back in line. Hohum. 

Will be monitoring canary like a nervous miner.

