### PR TITLE
Fixes scalar lookups for primary_key [and all keys with mappings]

### DIFF
--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 26)
+VERSION = (0, 6, 27)
 
 
 def get_version():

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -1397,8 +1397,6 @@ class QuerySet(object):
         def lookup(obj, name):
             chunks = name.split('__')
             for chunk in chunks:
-                if hasattr(obj, '_db_field_map'):
-                    chunk = obj._db_field_map.get(chunk, chunk)
                 obj = getattr(obj, chunk)
             return obj
 

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -2864,6 +2864,19 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(plist[1], (20, False))
         self.assertEqual(plist[2], (30, True))
 
+    def test_scalar_primary_key(self):
+
+        class SettingValue(Document):
+            key = StringField(primary_key=True)
+            value = StringField()
+
+        SettingValue.drop_collection()
+        s = SettingValue(key="test", value="test value")
+        s.save()
+
+        val = SettingValue.objects.scalar('key', 'value')
+        self.assertEqual(list(val), [('test', 'test value')])
+
     def test_scalar_cursor_behaviour(self):
         """Ensure that a query returns a valid set of results.
         """

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -2877,6 +2877,19 @@ class QuerySetTest(unittest.TestCase):
         val = SettingValue.objects.scalar('key', 'value')
         self.assertEqual(list(val), [('test', 'test value')])
 
+    def test_scalar_with_db_field_mapping(self):
+
+        class SettingValue(Document):
+            key = StringField(db_field='k')
+            value = StringField()
+
+        SettingValue.drop_collection()
+        s = SettingValue(key="test", value="test value")
+        s.save()
+
+        val = SettingValue.objects.scalar('key', 'value')
+        self.assertEqual(list(val), [('test', 'test value')])
+
     def test_scalar_cursor_behaviour(self):
         """Ensure that a query returns a valid set of results.
         """


### PR DESCRIPTION
fixes hmarr/mongoengine#519

This allows us to use qs.values_list() on things other than `id`, without getting AttributeErrors. Required for https://github.com/conversocial/conversocial/pull/19840/files#diff-ef213d0c3f3d87383d9e53f56e973af9R212 