### PR TITLE
DAF-44 — Coerce object ids to correct text type

### DIFF
--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -14,7 +14,7 @@ from .signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 7, 0)
+VERSION = (0, 7, 1)
 
 
 def get_version():

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -472,7 +472,7 @@ class ObjectIdField(BaseField):
     def to_mongo(self, value):
         if not isinstance(value, ObjectId):
             try:
-                return ObjectId(str(value))
+                return ObjectId(six.text_type(value))
             except Exception as e:
                 # e.message attribute has been deprecated since Python 2.6
                 self.error(six.text_type(e))
@@ -483,9 +483,9 @@ class ObjectIdField(BaseField):
 
     def validate(self, value):
         try:
-            ObjectId(str(value))
-        except:
-            self.error('Invalid Object ID')
+            ObjectId(six.text_type(value))
+        except Exception as e:
+            self.error(six.text_type(e))
 
 
 class DocumentMetaclass(type):


### PR DESCRIPTION
Although proper object ids should be coercable to str, passing in non-ascii unicode results in a less-than-useful exception message.

Also, validation did mask the actual underlying error with an opaque "Invalid Object ID" error