### PR TITLE
fix: noticket - do not create collections when querying

### DIFF
--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -14,7 +14,7 @@ from .signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 7, 2)
+VERSION = (0, 7, 3)
 
 
 def get_version():

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -137,8 +137,6 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
                         collection_name, **opts
                     )
             else:
-                if collection_name not in db.collection_names():
-                    db.create_collection(collection_name)
                 cls._collection = db[collection_name]
         return cls._collection
 

--- a/tests/document.py
+++ b/tests/document.py
@@ -466,6 +466,20 @@ class DocumentTest(unittest.TestCase):
         Person.drop_collection()
         self.assertFalse(collection in self.db.collection_names())
 
+    def test_non_capped_collections_no_created_on_query(self):
+        """Ensure that non capped (standard) collections are not created on
+        query.
+        """
+
+        self.Person.drop_collection()
+        self.assertFalse('person' in self.db.collection_names())
+
+        self.assertEqual(
+            list(self.Person.objects.filter(name="John")),
+            [])
+
+        self.assertFalse('person' in self.db.collection_names())
+
     def test_collection_name_and_primary(self):
         """Ensure that a collection with a specified name may be used.
         """


### PR DESCRIPTION
This brings our MongoEngine fork in line with: mongo shell, pymongo, upstream MongoEngine and shardmonster.