### PR TITLE
DAF-44 — Upgrade tests from py34 to py36

### DIFF
--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -14,7 +14,7 @@ from .signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 7, 3)
+VERSION = (0, 7, 4)
 
 
 def get_version():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34
+envlist = py27, py36
 
 [testenv]
 commands = {envpython} setup.py test


### PR DESCRIPTION
After the Ubuntu upgrade, we’re now targeting Python 3.6