### PR TITLE
fix: MONSTER-65 - fix for default 'id' field creation

### DIFF
--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -14,7 +14,7 @@ from .signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 7, 5)
+VERSION = (0, 7, 6)
 
 
 def get_version():

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -769,9 +769,14 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
                     new_class.id = field
 
         if not new_class._meta['id_field']:
-            new_class._meta['id_field'] = 'id'
-            new_class._fields['id'] = ObjectIdField(db_field='_id')
-            new_class.id = new_class._fields['id']
+            id_name, id_db_field = ('id', '_id')
+            new_class._meta['id_field'] = id_name
+            new_class._fields[id_name] = ObjectIdField(db_field=id_db_field)
+            new_class._fields[id_name].name = id_name
+            new_class._fields[id_name].primary_key = True
+            new_class.id = new_class._fields[id_name]
+            new_class._db_field_map[id_name] = id_db_field
+            new_class._reverse_db_field_map[id_db_field] = id_name
 
         return new_class
 

--- a/tests/document.py
+++ b/tests/document.py
@@ -631,6 +631,17 @@ class DocumentTest(unittest.TestCase):
         with self.assertRaises(pymongo.errors.OperationFailure):
             self.assertEqual(BlogPost.objects.hint([('ZZ', 1)]).count(), 10)
 
+    def test_default_id_field(self):
+        """Ensure that documents created without specifying an id field
+        are setup correctly.
+        """
+        class User(Document):
+            name = StringField()
+
+        self.assertEqual(User.id.name, 'id')
+        self.assertEqual(User.id.db_field, '_id')
+        self.assertEqual(User.id.primary_key, True)
+
     def test_custom_id_field(self):
         """Ensure that documents may be created with custom primary keys.
         """


### PR DESCRIPTION
Mainly from, this PR with one addition of setting primary_key and an
extra test.
https://github.com/MongoEngine/mongoengine/pull/961/

Internally MongoEngine maintains a mapping of field names to values in a
dictionary called `_data`. Due to an issue where the automatic id field
is created with a name attribute set to `None` it causes the id
attribute to be stored under `None` in the `_data` dictionary.

The shard key checks use this internal mapping to check if you're
updating the shardkey. These fail if your shard key contains the `id`
field.